### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -44,7 +44,7 @@ isSummertime	KEYWORD2
 isDateAlreadySet	KEYWORD2
 
 attachAlarm	KEYWORD2
-detachAlarm KEYWORD2
+detachAlarm	KEYWORD2
 disableAlarmTime	KEYWORD2
 disableAlarmDate	KEYWORD2
 
@@ -71,4 +71,4 @@ US	LITERAL1
 EEC	LITERAL1
 
 __TIME__	LITERAL1
-__DATE__	LITERAL1
+__DATE__	LITERAL1  


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords